### PR TITLE
Filter list of datasets by idtype / rowtype / coltype

### DIFF
--- a/phovea_server/dataset_api.py
+++ b/phovea_server/dataset_api.py
@@ -63,7 +63,7 @@ def _list_format_csv(data):
 
 
 def _to_query(query):
-  keys = ['name', 'id', 'fqname', 'type']
+  keys = ['name', 'id', 'fqname', 'type', 'idtype', 'coltype', 'rowtype']
   act_query = {k: v for k, v in query.items() if k in keys}
   if len(act_query) == 0:  # no query
     return lambda x: True


### PR DESCRIPTION
List all datasets with artists as idtype: http://localhost:8080/api/dataset/?idtype=artist
**Note** `idtype` is not available for matrices. Query for matrices using `rowtype` or `columntype`

List all matrices with idtype GENE_SYMBOL as rowtype: http://localhost:8080/api/dataset/?type=matrix&rowtype=GENE_SYMBOL