### PR TITLE
Fix UTF-8 encoded CSV handling

### DIFF
--- a/phovea_server/dataset_csv.py
+++ b/phovea_server/dataset_csv.py
@@ -60,8 +60,8 @@ class CSVEntryMixin(object):
 
     data = []
     with io.open(self._path, 'r', newline='', encoding=self._desc.get('encoding', 'utf-8')) as csvfile:
-      reader = csv.reader(csvfile, delimiter=self._desc.get('separator', ','),
-                          quotechar=str(self._desc.get('quotechar', '|')))
+      reader = csv.reader(csvfile, delimiter=self._desc.get('separator', u','),
+                          quotechar=str(self._desc.get('quotechar', u'|')))
       data.extend(reader)
 
     # print data
@@ -192,8 +192,8 @@ class CSVStratification(CSVEntryMixin, AStratification):
       clusters = set()
       count = 0
       with io.open(path, 'r', newline='', encoding=desc.get('encoding', 'utf-8')) as csvfile:
-        reader = csv.reader(csvfile, delimiter=desc.get('separator', ','),
-                            quotechar=str(desc.get('quotechar', '|')))
+        reader = csv.reader(csvfile, delimiter=desc.get('separator', u','),
+                            quotechar=str(desc.get('quotechar', u'|')))
         for row in reader:
           count += 1
           clusters.add(row[1])
@@ -309,8 +309,8 @@ class CSVMatrix(CSVEntryMixin, AMatrix):
       min_v = None
       max_v = None
       with io.open(path, 'r', newline='', encoding=desc.get('encoding', 'utf-8')) as csvfile:
-        reader = csv.reader(csvfile, delimiter=desc.get('separator', ','),
-                            quotechar=str(desc.get('quotechar', '|')))
+        reader = csv.reader(csvfile, delimiter=desc.get('separator', u','),
+                            quotechar=str(desc.get('quotechar', u'|')))
         for row in reader:
           if cols is None:
             cols = len(row) - 1

--- a/phovea_server/dataset_csv.py
+++ b/phovea_server/dataset_csv.py
@@ -59,7 +59,7 @@ class CSVEntryMixin(object):
       return self._loaded
 
     data = []
-    with io.open(self._path, 'r', newline='', encoding='utf-8') as csvfile:
+    with io.open(self._path, 'r', newline='', encoding=self._desc.get('encoding', 'utf-8')) as csvfile:
       reader = csv.reader(csvfile, delimiter=self._desc.get('separator', ','),
                           quotechar=str(self._desc.get('quotechar', '|')))
       data.extend(reader)
@@ -191,7 +191,7 @@ class CSVStratification(CSVEntryMixin, AStratification):
     else:  # derive from the data
       clusters = set()
       count = 0
-      with io.open(path, 'r', newline='', encoding='utf-8') as csvfile:
+      with io.open(path, 'r', newline='', encoding=desc.get('encoding', 'utf-8')) as csvfile:
         reader = csv.reader(csvfile, delimiter=desc.get('separator', ','),
                             quotechar=str(desc.get('quotechar', '|')))
         for row in reader:
@@ -308,7 +308,7 @@ class CSVMatrix(CSVEntryMixin, AMatrix):
       cols = None
       min_v = None
       max_v = None
-      with io.open(path, 'r', newline='', encoding='utf-8') as csvfile:
+      with io.open(path, 'r', newline='', encoding=desc.get('encoding', 'utf-8')) as csvfile:
         reader = csv.reader(csvfile, delimiter=desc.get('separator', ','),
                             quotechar=str(desc.get('quotechar', '|')))
         for row in reader:
@@ -449,7 +449,7 @@ def to_files(plugins):
     index = os.path.join(plugin.folder + '/data/' if not hasattr(plugin, 'inplace') else plugin.folder, 'index.json')
     if not os.path.isfile(index):
       continue
-    with io.open(index, 'r', newline='', encoding='utf-8') as f:
+    with open(index, 'r') as f:
       desc = json.load(f)
       for di in desc:
         if di['type'] == 'matrix':
@@ -485,10 +485,10 @@ class DataPlugin(object):
     index = os.path.join(self.folder, 'index.json')
     old = []
     if os.path.isfile(index):
-      with io.open(index, 'r', newline='', encoding='utf-8') as f:
+      with io.open(index, 'r', newline='', encoding=desc.get('encoding', 'utf-8')) as f:
         old = json.load(f)
     old.append(desc)
-    with io.open(index, 'w', newline='', encoding='utf-8') as f:
+    with io.open(index, 'w', newline='', encoding=desc.get('encoding', 'utf-8')) as f:
       json.dump(old, f, indent=1)
 
 

--- a/phovea_server/dataset_csv.py
+++ b/phovea_server/dataset_csv.py
@@ -7,7 +7,8 @@
 
 from builtins import str, object
 import json
-import csv
+from backports import csv
+import io
 import os
 import numpy as np
 from .dataset_def import ADataSetProvider, AColumn, AMatrix, AStratification, ATable, AVector
@@ -58,9 +59,9 @@ class CSVEntryMixin(object):
       return self._loaded
 
     data = []
-    with open(self._path, 'r') as csvfile:
-      reader = csv.reader(csvfile, delimiter=self._desc.get('separator', ',').encode('ascii', 'ignore'),
-                          quotechar=str(self._desc.get('quotechar', '|')).encode('ascii', 'ignore'))
+    with io.open(self._path, 'r', newline='', encoding='utf-8') as csvfile:
+      reader = csv.reader(csvfile, delimiter=self._desc.get('separator', ','),
+                          quotechar=str(self._desc.get('quotechar', '|')))
       data.extend(reader)
 
     # print data
@@ -190,9 +191,9 @@ class CSVStratification(CSVEntryMixin, AStratification):
     else:  # derive from the data
       clusters = set()
       count = 0
-      with open(path, 'r') as csvfile:
-        reader = csv.reader(csvfile, delimiter=desc.get('separator', ',').encode('ascii', 'ignore'),
-                            quotechar=str(desc.get('quotechar', '|')).encode('ascii', 'ignore'))
+      with io.open(path, 'r', newline='', encoding='utf-8') as csvfile:
+        reader = csv.reader(csvfile, delimiter=desc.get('separator', ','),
+                            quotechar=str(desc.get('quotechar', '|')))
         for row in reader:
           count += 1
           clusters.add(row[1])
@@ -307,9 +308,9 @@ class CSVMatrix(CSVEntryMixin, AMatrix):
       cols = None
       min_v = None
       max_v = None
-      with open(path, 'r') as csvfile:
-        reader = csv.reader(csvfile, delimiter=desc.get('separator', ',').encode('ascii', 'ignore'),
-                            quotechar=str(desc.get('quotechar', '|')).encode('ascii', 'ignore'))
+      with io.open(path, 'r', newline='', encoding='utf-8') as csvfile:
+        reader = csv.reader(csvfile, delimiter=desc.get('separator', ','),
+                            quotechar=str(desc.get('quotechar', '|')))
         for row in reader:
           if cols is None:
             cols = len(row) - 1
@@ -448,7 +449,7 @@ def to_files(plugins):
     index = os.path.join(plugin.folder + '/data/' if not hasattr(plugin, 'inplace') else plugin.folder, 'index.json')
     if not os.path.isfile(index):
       continue
-    with open(index, 'r') as f:
+    with io.open(index, 'r', newline='', encoding='utf-8') as f:
       desc = json.load(f)
       for di in desc:
         if di['type'] == 'matrix':
@@ -484,10 +485,10 @@ class DataPlugin(object):
     index = os.path.join(self.folder, 'index.json')
     old = []
     if os.path.isfile(index):
-      with open(index, 'r') as f:
+      with io.open(index, 'r', newline='', encoding='utf-8') as f:
         old = json.load(f)
     old.append(desc)
-    with open(index, 'w') as f:
+    with io.open(index, 'w', newline='', encoding='utf-8') as f:
       json.dump(old, f, indent=1)
 
 

--- a/phovea_server/mapping_csv.py
+++ b/phovea_server/mapping_csv.py
@@ -33,11 +33,13 @@ class FileMapper(object):
     pass
 
   def _load(self):
-    import csv
+    from backports import csv
+    import io
 
     _log.info('loading real mapping file from %s to %s', self.from_idtype, self.to_idtype)
-    with open(self._path, 'r', 'utf-8') as csvfile:
-      reader = csv.reader(csvfile, delimiter=self._desc.get('separator', ',').encode('ascii', 'ignore'), quotechar='"')
+    with io.open(self._path, 'r', newline='', encoding=self._desc.get('encoding', 'utf-8')) as csvfile:
+      reader = csv.reader(csvfile, delimiter=self._desc.get('separator', u','),
+                          quotechar=str(self._desc.get('quotechar', u'"')))
       self._map = dict()
       for i, line in enumerate(reader):
         if i == 0 and self._desc.get('header', False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ matplotlib==1.5.3
 Pillow==4.0.0
 json-cfg==0.4.1
 future==0.16.0
+backports.csv==1.0.5


### PR DESCRIPTION
Fixes #60 

Uses https://pypi.python.org/pypi/backports.csv as suggested [here](https://stackoverflow.com/a/35444608).

Loading the UTF-8 encoded CSV after the fix without problems:

![image](https://user-images.githubusercontent.com/5851088/34107108-3e20fa60-e3fb-11e7-9d4c-4a9ecdaae382.png)

The encoding can be optionally defined in the dataset description in the index.json (the default is set to `utf-8`):

```json
[
  {
    "name": "ut8-encoded-header",
    "encoding": "utf-8",
    "separator": "\t",
    "value": {
      "range": [
        0,
        1
      ],
      "type": "real"
    },
    "rowtype": "Country",
    "coltype": "Artist",
    "path": "ut8-encoded-header.csv",
    "type": "matrix",
    "size": [
      1,
      9
    ]
  }
]
```