### PR TITLE
Sgratzl/rest cache

### DIFF
--- a/phovea_server/config.json
+++ b/phovea_server/config.json
@@ -10,6 +10,8 @@
   "dir": "./",
   "dataDir": "${dir}_data",
   "absoluteDataDir": "${absoluteDir}_data",
+  "restCacheDir": "${dir}_cache",
+  "restCache": false, // record, true
 
   "secret_key": "VERY_SECRET_STUFF_T0IB84wlQrdMH8RVT28w",
   "max_file_size": 33554432,

--- a/phovea_server/ns.py
+++ b/phovea_server/ns.py
@@ -39,7 +39,6 @@ def no_cache(f):
 def etag(f):
   """Add entity tag (etag) handling to the decorated route."""
   import functools
-  import hashlib
 
   @functools.wraps(f)
   def wrapped(*args, **kwargs):
@@ -58,39 +57,6 @@ def etag(f):
     if rv.status_code != 200 or rv.direct_passthrough or not rv.implicit_sequence_conversion:
       return rv
 
-    # compute the etag for this request as the MD5 hash of the response
-    # text and set it in the response header
-    etag = '"' + hashlib.sha1(rv.get_data()).hexdigest() + '"'
-    rv.headers['ETag'] = etag
-    rv.headers['Cache-Control'] = 'must-revalidate'
-
-    # handle If-Match and If-None-Match request headers if present
-    if_match = request.headers.get('If-Match')
-    if_none_match = request.headers.get('If-None-Match')
-    # weak version with prefixed W/
-    weak_etag = 'W/' + etag
-
-    if if_match:
-      # only return the response if the etag for this request matches
-      # any of the etags given in the If-Match header. If there is no
-      # match, then return a 412 Precondition Failed status code
-      etag_list = [tag.strip() for tag in if_match.split(',')]
-      if etag not in etag_list and weak_etag not in etag_list and '*' not in etag_list:
-        response = jsonify({'status': 412, 'error': 'precondition failed',
-                            'message': 'precondition failed'})
-        response.headers['Cache-Control'] = 'must-revalidate'
-        response.status_code = 412
-        return response
-    elif if_none_match:
-      # only return the response if the etag for this request does not
-      # match any of the etags given in the If-None-Match header. If
-      # one matches, then return a 304 Not Modified status code
-      etag_list = [tag.strip() for tag in if_none_match.split(',')]
-      if etag in etag_list or weak_etag in etag_list or '*' in etag_list:
-        response = jsonify({'status': 304, 'error': 'not modified',
-                            'message': 'resource not modified'})
-        response.headers['Cache-Control'] = 'must-revalidate'
-        response.status_code = 304
-        return response
-    return rv
+    rv.add_etag()
+    return rv.make_conditional(request)
   return wrapped

--- a/phovea_server/server.py
+++ b/phovea_server/server.py
@@ -37,6 +37,52 @@ def _add_no_cache_header(response):
   return response
 
 
+def _rest_cache(namespace):
+  import os
+  from os import path
+  import hashlib
+  from werkzeug import url_quote
+
+  dir_name = path.join(cc.restCacheDir, namespace[1:])
+  if not path.exists(dir_name):
+    os.makedirs(dir_name)
+
+  def to_filename(request):
+    secure = url_quote(request.full_path[1:].replace('/', ' ').replace('?', '_').replace('=', '-').replace('&', '_'), safe=' ')
+    key = hashlib.sha256(namespace + secure).hexdigest()
+    file_name = '{}_{}.json'.format(secure[:min(128, len(secure))], key)
+    return file_name.replace('%', '_')
+
+  def save(response):
+    from flask import request
+
+    if request.method != 'GET' or response.status_code != 200 or response.mimetype != 'application/json' or
+    response.is_streamed or response.cache_control.no_cache:
+      return response
+
+    file_name = to_filename(request)
+    _log.info('cache %s %s -> %s %s', namespace, request.full_path, dir_name, file_name)
+
+    with open(path.join(dir_name, file_name), 'w') as f:
+      f.write(response.get_data())
+
+    # print(response.mimetype, data)
+    return response
+
+  def load():
+    from flask import request, send_from_directory
+    file_name = to_filename(request)
+
+    full = path.join(dir_name, file_name)
+
+    if path.exists(full):
+      _log.info('use cache cache %s %s <- %s', namespace, request.full_path, full)
+      return send_from_directory(path.abspath(dir_name), file_name, add_etags=False)
+    return None
+
+  return save, load
+
+
 def _to_stack_trace():
   import traceback
   return traceback.format_exc()
@@ -46,7 +92,7 @@ def _exception_handler(error):
   return 'Internal Server Error\n' + _to_stack_trace(), 500
 
 
-def _init_app(app, is_default_app=False):
+def _init_app(app, namespace, is_default_app=False):
   """
   initializes an application by setting common properties and options
   :param app:
@@ -68,6 +114,11 @@ def _init_app(app, is_default_app=False):
   if cc.error_stack_trace and hasattr(app, 'register_error_handler'):
     app.register_error_handler(500, _exception_handler)
 
+  if cc['restCache'] == 'record' and hasattr(app, 'after_request'):
+    app.after_request(_rest_cache(namespace)[0])
+  if cc['restCache'] is True and hasattr(app, 'before_request'):
+    app.before_request(_rest_cache(namespace)[1])
+
   if cc.secret_key:
     app.config['SECRET_KEY'] = cc.secret_key
 
@@ -85,7 +136,7 @@ def _loader(p):
 
   def load_app():
     app = p.load().factory()
-    _init_app(app)
+    _init_app(app, p.namespace)
     return app
 
   return load_app
@@ -117,7 +168,7 @@ def create_application():
 
   # create a path dispatcher
   _default_app = mainapp.default_app()
-  _init_app(_default_app, True)
+  _init_app(_default_app, '/', True)
   _applications = {p.namespace: _loader(p) for p in list_plugins('namespace')}
 
   # create a dispatcher for all the applications

--- a/phovea_server/server.py
+++ b/phovea_server/server.py
@@ -56,8 +56,7 @@ def _rest_cache(namespace):
   def save(response):
     from flask import request
 
-    if request.method != 'GET' or response.status_code != 200 or response.mimetype != 'application/json' or
-    response.is_streamed or response.cache_control.no_cache:
+    if request.method != 'GET' or response.status_code != 200 or response.mimetype != 'application/json' or response.is_streamed or response.cache_control.no_cache:
       return response
 
     file_name = to_filename(request)


### PR DESCRIPTION
add option in the config to record or use a cache for all the incoming rest requests. see `restCache` config option. Only 200 get requests that result in a regular JSON flie are cached if enabled. The cache key is a combination of the url and its hash value. 