### PR TITLE
Clehner/rest cache update

### DIFF
--- a/phovea_server/server.py
+++ b/phovea_server/server.py
@@ -52,10 +52,10 @@ def _rest_cache(namespace):
     secure = url_quote(request.full_path[1:].replace('/', ' ').replace('?', '_').replace('=', '-').replace('&', '_'), safe=' ')
     key = hashlib.sha256(namespace + secure).hexdigest()
     file_name_old = '{}_{}.json'.format(secure[:min(128, len(secure))], key)
-    file_name = '{}_{}.json'.format(secure[:min(48, len(secure))], key)  # use a shorter filename for restCache, to avoid file system errors with too long file names
+    file_name = '{}_{}.json'.format(secure[:min(64, len(secure))], key)  # use a shorter filename for restCache, to avoid file system errors with too long file names
     return {
       "file_name_128": file_name_old.replace('%', '_'),  # file_name_128 = file name with 128 characters in front of the hash
-      "file_name_48": file_name.replace('%', '_')  # file_name_48 = file name with 48 characters in front of the hash
+      "file_name_64": file_name.replace('%', '_')  # file_name_64 = file name with 64 characters in front of the hash
     }
 
   def save(response):
@@ -64,7 +64,7 @@ def _rest_cache(namespace):
     if request.method != 'GET' or response.status_code != 200 or response.mimetype != 'application/json' or response.is_streamed or response.cache_control.no_cache:
       return response
 
-    file_name = to_filename(request)['file_name_48']  # only use the short file name for storing new files
+    file_name = to_filename(request)['file_name_64']  # only use the short file name for storing new files
 
     _log.info('cache %s %s -> %s %s', namespace, request.full_path, dir_name, file_name)
 
@@ -79,8 +79,8 @@ def _rest_cache(namespace):
 
     file_names = to_filename(request)
 
-    # use the legacy file name ('file_name_old') if a file with this name exists and the new file name format otherwise
-    file_name = file_names['file_name_128'] if path.exists(file_names['file_name_128']) else file_names['file_name']
+    # use the legacy file name ('file_name_128') if a file with this name exists and the new file name format otherwise
+    file_name = file_names['file_name_128'] if path.exists(file_names['file_name_128']) else file_names['file_name_64']
 
     full = path.join(dir_name, file_name)
 

--- a/phovea_server/server.py
+++ b/phovea_server/server.py
@@ -64,10 +64,7 @@ def _rest_cache(namespace):
     if request.method != 'GET' or response.status_code != 200 or response.mimetype != 'application/json' or response.is_streamed or response.cache_control.no_cache:
       return response
 
-    file_names = to_filename(request)
-
-    # use the legacy file name ('file_name_old') if a file with this name exists and the new file name format otherwise
-    file_name = file_names['file_name_old'] if path.exists(file_names['file_name_old']) else file_names['file_name']
+    file_name = to_filename(request)['file_name']  # only use the new file name
 
     _log.info('cache %s %s -> %s %s', namespace, request.full_path, dir_name, file_name)
 
@@ -79,7 +76,11 @@ def _rest_cache(namespace):
 
   def load():
     from flask import request, send_from_directory
-    file_name = to_filename(request)['file_name']  # only use the new file name
+
+    file_names = to_filename(request)
+
+    # use the legacy file name ('file_name_old') if a file with this name exists and the new file name format otherwise
+    file_name = file_names['file_name_old'] if path.exists(file_names['file_name_old']) else file_names['file_name']
 
     full = path.join(dir_name, file_name)
 

--- a/phovea_server/server.py
+++ b/phovea_server/server.py
@@ -54,8 +54,8 @@ def _rest_cache(namespace):
     file_name_old = '{}_{}.json'.format(secure[:min(128, len(secure))], key)
     file_name = '{}_{}.json'.format(secure[:min(48, len(secure))], key)  # use a shorter filename for restCache, to avoid file system errors with too long file names
     return {
-      "file_name_old": file_name_old.replace('%', '_'),
-      "file_name": file_name.replace('%', '_')
+      "file_name_128": file_name_old.replace('%', '_'),  # file_name_128 = file name with 128 characters in front of the hash
+      "file_name_48": file_name.replace('%', '_')  # file_name_48 = file name with 48 characters in front of the hash
     }
 
   def save(response):
@@ -64,7 +64,7 @@ def _rest_cache(namespace):
     if request.method != 'GET' or response.status_code != 200 or response.mimetype != 'application/json' or response.is_streamed or response.cache_control.no_cache:
       return response
 
-    file_name = to_filename(request)['file_name']  # only use the new file name
+    file_name = to_filename(request)['file_name_48']  # only use the short file name for storing new files
 
     _log.info('cache %s %s -> %s %s', namespace, request.full_path, dir_name, file_name)
 
@@ -80,7 +80,7 @@ def _rest_cache(namespace):
     file_names = to_filename(request)
 
     # use the legacy file name ('file_name_old') if a file with this name exists and the new file name format otherwise
-    file_name = file_names['file_name_old'] if path.exists(file_names['file_name_old']) else file_names['file_name']
+    file_name = file_names['file_name_128'] if path.exists(file_names['file_name_128']) else file_names['file_name']
 
     full = path.join(dir_name, file_name)
 

--- a/phovea_server/server.py
+++ b/phovea_server/server.py
@@ -6,8 +6,6 @@
 from __future__ import absolute_import
 import gevent.monkey
 import logging.config
-from os import path
-
 
 gevent.monkey.patch_all()  # ensure the standard libraries are patched
 

--- a/phovea_server/server.py
+++ b/phovea_server/server.py
@@ -6,6 +6,7 @@
 from __future__ import absolute_import
 import gevent.monkey
 import logging.config
+from os import path
 
 
 gevent.monkey.patch_all()  # ensure the standard libraries are patched
@@ -50,8 +51,12 @@ def _rest_cache(namespace):
   def to_filename(request):
     secure = url_quote(request.full_path[1:].replace('/', ' ').replace('?', '_').replace('=', '-').replace('&', '_'), safe=' ')
     key = hashlib.sha256(namespace + secure).hexdigest()
-    file_name = '{}_{}.json'.format(secure[:min(128, len(secure))], key)
-    return file_name.replace('%', '_')
+    file_name_old = '{}_{}.json'.format(secure[:min(128, len(secure))], key)
+    file_name = '{}_{}.json'.format(secure[:min(48, len(secure))], key)  # use a shorter filename for restCache, to avoid file system errors with too long file names
+    return {
+      "file_name_old": file_name_old.replace('%', '_'),
+      "file_name": file_name.replace('%', '_')
+    }
 
   def save(response):
     from flask import request
@@ -59,7 +64,11 @@ def _rest_cache(namespace):
     if request.method != 'GET' or response.status_code != 200 or response.mimetype != 'application/json' or response.is_streamed or response.cache_control.no_cache:
       return response
 
-    file_name = to_filename(request)
+    file_names = to_filename(request)
+
+    # use the legacy file name ('file_name_old') if a file with this name exists and the new file name format otherwise
+    file_name = file_names['file_name_old'] if path.exists(file_names['file_name_old']) else file_names['file_name']
+
     _log.info('cache %s %s -> %s %s', namespace, request.full_path, dir_name, file_name)
 
     with open(path.join(dir_name, file_name), 'w') as f:
@@ -70,7 +79,7 @@ def _rest_cache(namespace):
 
   def load():
     from flask import request, send_from_directory
-    file_name = to_filename(request)
+    file_name = to_filename(request)['file_name']  # only use the new file name
 
     full = path.join(dir_name, file_name)
 


### PR DESCRIPTION
I've updated the restCache such that shorter file names are used (64 characters and then the hash of the request instead of the first 128 characters)

the problem with 128 characters and the hash is that the resulting file names hit the my boundaries (ext4 supports 255 characters long file) names, but by using an encrypted home partition on my system the boundary is much lower --> around 140 characters --> see also https://unix.stackexchange.com/a/32834

on windows there is a similar boundary

so when recording test data with the restCache an internal server error is thrown, when the server tries to save the file

furthermore test data files with such long file names cannot be used, since these files cannot be saved

HINT: I was not able to fully test the backwards compatibility since, I cannot create the test data