### PR TITLE
Allow POST method for <dataset>/data route for long parameters

### DIFF
--- a/phovea_server/dataset_specific.py
+++ b/phovea_server/dataset_specific.py
@@ -196,11 +196,11 @@ def _add_handler(app, dataset_getter, type):
 
   def data_gen(dataset_id):
     d = dataset_getter(dataset_id, type)
-    r = asrange(ns.request.args.get('range', None))
-    formatter = resolve_formatter(type, ns.request.args.get('format', 'json'))
-    return formatter(d, r, args=ns.request.args)
+    r = asrange(ns.request.values.get('range', None))
+    formatter = resolve_formatter(type, ns.request.values.get('format', 'json'))
+    return formatter(d, r, args=ns.request.values)
 
-  app.add_url_rule('/' + type + '/<dataset_id>/data', 'data_' + type, ns.etag(data_gen))
+  app.add_url_rule('/' + type + '/<dataset_id>/data', 'data_' + type, ns.etag(data_gen), methods=['GET', 'POST'])
 
 
 def add_table_handler(app, dataset_getter):


### PR DESCRIPTION
Coming from the related issue phovea/phovea_vis#69 we need to pass long ranges as parameter to the server. With the GET methods the server cancels the request and returns an HTTP error 431. 

This PR allows the transfer of parameters by POST method. With this implementation the request is processed as expected.

The implementation is similar to TDP core, where long URLs are also send via POST method. However, we should be aware that this change breaks the concept of a REST api, as we misuse the POST for fetching a resource instead of creating a new resource.