### PR TITLE
Fix deprecated/removed Werkzeug `ProxyFix` import

### DIFF
--- a/phovea_server/server.py
+++ b/phovea_server/server.py
@@ -168,7 +168,7 @@ def create_application():
   from . import dispatcher
   from . import mainapp
   from .plugin import list as list_plugins
-  from werkzeug.contrib.fixers import ProxyFix
+  from werkzeug.middleware.proxy_fix import ProxyFix
 
   # create a path dispatcher
   _default_app = mainapp.default_app()


### PR DESCRIPTION
Fixes #105

### Summary

With the release of Werkzeug v1.0.0 the former deprecated packages were removed and cause some errors. According to the Werkzeug changelog the module are moved from `contrib` to `middleware`.

From the [Werkzeug v0.15.0 changelog](https://github.com/pallets/werkzeug/blob/dfde671ef969e27c7b14bd464688c009b34a7d2b/CHANGES.rst#version-0150)

![grafik](https://user-images.githubusercontent.com/5851088/74023762-b0eae300-49a0-11ea-8d42-358f821d2fa0.png)

### Test this fix

Run `docker-compose build --force api` to rebuild the container and download all dependencies again. Then run `docker-compose up`. Before this fix the start will fail, with this fix it should succeed.