### PR TITLE
Add build args for injection of env vars in Dockerfile_dev

### DIFF
--- a/deploy/Dockerfile_dev
+++ b/deploy/Dockerfile_dev
@@ -1,6 +1,14 @@
 FROM python:3.7-buster
 
 LABEL maintainer="contact@caleydo.org"
+
+ARG http_proxy
+ARG HTTP_PROXY
+ARG https_proxy
+ARG HTTPS_PROXY
+ARG no_proxy
+ARG NO_PROXY
+
 WORKDIR /phovea
 
 # install dependencies last step such that everything before can be cached

--- a/deploy/docker-compose.partial.yml
+++ b/deploy/docker-compose.partial.yml
@@ -4,6 +4,13 @@ services:
     build:
       context: .
       dockerfile: deploy/Dockerfile_dev
+      args:
+        - http_proxy
+        - HTTP_PROXY
+        - https_proxy
+        - HTTPS_PROXY
+        - no_proxy
+        - NO_PROXY
     ports:
     - '9000:80'
     volumes:


### PR DESCRIPTION
This allows to add environment variables at build time.

This requires `docker-compose.yml` to have:

```
version: '2.0'
services:
  ...
  api:
    build:
      ...
      args:
        - http_proxy
        - HTTP_PROXY
        - https_proxy
        - HTTPS_PROXY
        - no_proxy
        - NO_PROXY
        ...
    ports:
      ...
```

present. Changes in the environment will be picked up and
environment variables that are unset will not be set.

Closes phovea/phovea_server#110