### PR TITLE
Update Dockerfile

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,7 +3,6 @@ FROM python:3.7-buster
 LABEL maintainer="contact@caleydo.org"
 WORKDIR /phovea
 
-RUN printf "deb http://deb.debian.org/debian/ buster main\ndeb-src http://deb.debian.org/debian/ buster main\ndeb http://deb.debian.org/debian-security/ buster/updates main\ndeb-src http://deb.debian.org/debian-security/ buster/updates main" > /etc/apt/sources.list
 # install dependencies last step such that everything before can be cached
 COPY requirements*.txt docker_packages.txt docker_script*.sh _docker_data* ./
 RUN (!(test -s docker_packages.txt) || (apt-get update && \


### PR DESCRIPTION
this line was needed because of some jessie bugs (see #97); now we can remove it (because otherwise phovea_molecule doesn't work)