### PR TITLE
Release 4.1.0

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,7 +3,6 @@ FROM python:3.7-buster
 LABEL maintainer="contact@caleydo.org"
 WORKDIR /phovea
 
-RUN printf "deb http://deb.debian.org/debian/ buster main\ndeb-src http://deb.debian.org/debian/ buster main\ndeb http://deb.debian.org/debian-security/ buster/updates main\ndeb-src http://deb.debian.org/debian-security/ buster/updates main" > /etc/apt/sources.list
 # install dependencies last step such that everything before can be cached
 COPY requirements*.txt docker_packages.txt docker_script*.sh _docker_data* ./
 RUN (!(test -s docker_packages.txt) || (apt-get update && \

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prebuild": "node -e \"process.exit(process.env.PHOVEA_SKIP_TESTS === undefined?1:0)\" || npm run test",
     "build": "rm -rf build/source && find . -name '*.pyc' -delete && node buildPython.js && cp -r ./phovea_server build/source/",
     "predist": "npm run build && npm run docs",
-    "dist": "python setup.py sdist bdist_wheel && cd build && tar cvzf ../dist/phovea_server.tar.gz *",
+    "dist": "python setup.py sdist bdist_wheel",
     "publish": "twine upload --repository-url https://upload.pypi.org/legacy/ dist/*",
     "predocker": "npm run build",
     "docker": "docker build -t phovea_server -f deploy/Dockerfile .",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "phovea_server",
   "description": "Python server implementation of Phovea",
-  "version": "4.0.3-SNAPSHOT",
+  "version": "4.1.0",
   "author": {
     "name": "The Caleydo Team",
     "email": "contact@caleydo.org",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "phovea_server",
   "description": "Python server implementation of Phovea",
-  "version": "4.0.2",
+  "version": "4.0.3-SNAPSHOT",
   "author": {
     "name": "The Caleydo Team",
     "email": "contact@caleydo.org",


### PR DESCRIPTION
## Release notes

* Remove update of Debian sources list in Dockerfile #116


## Checklists

### Release preparation

* [x] Create new `release-x.x.x` branch (based on `develop` branch)
* [x] Collect changes and write [release notes](#release-notes)
* [x] Draft release PR in GitHub that merges the `release-x.x.x` into the `master` branch

### Release dependencies first

In case of dependent Phovea/TDP repositories follow [dependency tree](https://wiki.datavisyn.io/phovea/fundamentals/development-process#dependency-hierarchy) from the top:

* [ ] Release dependent repositories if they contain changes first before proceeding here
* [ ] Replace git dependencies in *package.json* with new version range (e.g., `"phovea_core": "^2.3.1"` when published on npm **or** `"phovea_core": "github:datavisyn/tdp_core#semver:^8.0.0"` for non-published repositories)
* [ ] Replace git dependencies in *requirements.txt* with new version range (e.g., `phovea_server>=2.3.0,<3.0.0` when published on pipy **or** `-e git+https://github.com/datavisyn/tdp_core.git@v8.0.0#egg=tdp_core` for non-published repositories)
* [ ] Commit and push new dependencies
* [ ] Wait until build is successful
* [ ] Repeat with other repositories/dependencies or proceed with next section

### Update version

* [x] Check version numbers of dependencies again
* [x] Check if build is successful
* [x] Update this version number following [semver](https://semver.org)
* [x] Commit and push *package.json* with new version number
* [x] Wait until build is successful
* [x] Assign reviewer and wait for final review
* [x] Merge this pull request into master branch
* [x] Add release label (i.e., `release: major`, `release: minor`, or `release: patch`)

### Publish pip release

The steps of this section are only necessary if the code is public and should be published to the pypi registry.

* [x] `chmod -R o+w .` in the cloned repository directory (to provide write access to the CircleCI Linux user)
* [x] `rm -rf dist && rm -rf build`
* [x] `docker run -it -v $(pwd):/phovea circleci/python:3.7-buster-node-browsers /bin/bash` and continue inside the container
* [x] `cd /phovea`
* [x] `sudo pip install -r requirements.txt && sudo pip install -r requirements_dev.txt && sudo pip install twine`
* [x] `npm run dist`
* [x] Ensure only two files are in the *dist* directory (*.whl and *.tar.gz)
* [x] Ensure that both files contain the new version number
* [x] `twine upload --repository-url https://upload.pypi.org/legacy/ dist/*`
* [x] Login with `caleydo-bot`
* [x] Check release on [pipy.org](https://pypi.org/)

### Create GitHub release

* [ ] Draft a new release (Code -> Releases -> Draft a new release)
* [ ] Use new version number as tag (e.g., `v2.3.1`)
* [ ] Copy [release notes](#release-notes)
* [ ] Publish release

### Prepeare next develop release

* [ ] Switch to `develop` branch
* [ ] Merge `master` branch into `develop` (`git merge origin/master`)
* [ ] Update version in *package.json* to `<next patch version>-SNAPSHOT` (e.g., `2.3.1` to `2.3.2-SNAPSHOT`)
* [ ] Revert dependencies in *requirements.txt* to develop branches (e.g., `-e git+https://github.com/phovea/phovea_server.git@develop#egg=phovea_server`)
* [ ] Commit and push changes
 
### 🏁 Finish line

* [ ] Inform colleagues and customers about the release
* [ ] Celebrate the new release 🥳
