### PR TITLE
Remove ssh command from docker-compose-debug-partial.yml

### DIFF
--- a/deploy/docker-compose-debug.partial.yml
+++ b/deploy/docker-compose-debug.partial.yml
@@ -3,4 +3,3 @@ services:
   api:
     ports:
       - '2222:22'
-    command: /usr/sbin/sshd -D


### PR DESCRIPTION
Closes phovea/phovea_server#119


### Summary 
Removed  the command `/usr/sbin/sshd -D`. 
The command was being used to enable PyCharm debugging.

However since updating to base image **python:3.7-buster** starting the container in debug 
mode with the cmd:
`./docker-compose-debug up`
 throws an error.

[PyCharm Debugging](https://wiki.datavisyn.io/phovea/development/workspace/pycharm-debugging#create-new-remote-python-interpreter-new-tutorial)  doesn't need an ssh server in the container to work, in the newest tutorial.
Thus the command can be safely removed.