### PR TITLE
Return correct order of mapped items

### DIFF
--- a/phovea_server/dataset_api.py
+++ b/phovea_server/dataset_api.py
@@ -11,6 +11,7 @@ from .util import jsonify, to_json
 import logging
 from .dataset import list_idtypes, get_idmanager, iter, get_mappingmanager, get, list_datasets, add, remove
 from flask import abort
+from typing import List
 
 
 app = ns.Namespace(__name__)
@@ -285,7 +286,14 @@ def _do_mapping(idtype, to_idtype, to_ids):
     ns.abort(400)
     return
 
-  mapped_list = mapper(idtype, to_idtype, names)
+  # we'll call the mapper for each name individually to preserve the order of the names,
+  # because otherwise it's not guaranteed that the results are in the same order as the names
+  # and since we need to merge the results on the frontend occasionally we might mix them up
+  mappers_list: List[List[List[str]]] = [mapper(idtype, to_idtype, [name]) for name in names]
+
+  # flatten the list to be 2-dimensional since this is the format we used to return
+  mapped_list: List[List[str]] = [mapping[0] for mapping in mappers_list]
+
   if first_only:
     mapped_list = [None if a is None or len(a) == 0 else a[0] for a in mapped_list]
 


### PR DESCRIPTION
This PR returns the mapped items in the order the names to be mapped were given. The problem was that in tdp_core's SelectionChooser (and other parts) we rely on the order of the elements to map them together. see also:

https://github.com/datavisyn/tdp_core/blob/develop/src/views/SelectionChooser.ts#L108-L112

The problem with this is if the backend cannot guarantee that the order the items are returned is the same as the order the request parameters are passed then we mix the lists and get wrong results.

what we're now doing is get the mappings for each request parameter separately in a loop and then return that list

this closes datavisyn/tdp_core#344