### PR TITLE
Fix segmentation fault error by new gevent version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,3 @@ pandas==1.0.1
 matplotlib==3.1.3
 Pillow==7.0.0
 json-cfg==0.4.2
-
-# pin greenlet version (see https://github.com/phovea/phovea_server/issues/130)
-greenlet==0.4.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==1.1.1
 flask-restplus==0.13.0
 Flask-Sockets==0.2.1
-gevent==1.4.0
+gevent==20.9.0
 gevent-websocket==0.10.1
 numpy==1.18.1
 scipy==1.4.1


### PR DESCRIPTION
fixes #130 

I've updated gevent to the latest version (i.e. the one released with the new greenlet version that causes the error).

I've tested the change locally with:
* Coral (develop)
* Ordino (open_source)

(Quick smoke tests with loading a cell lines/tissues, loading gene scores)

---

The version increase of gevent is a bit misleading. They changed the versioning this year:

![image](https://user-images.githubusercontent.com/10337788/94002471-39848b00-fd9a-11ea-9d1c-06acd75cf108.png)

i.e. version numbers are a combination of _year_ and _month_ plus _release counter_