### PR TITLE
Fix segmentation fault error by pinning greenlet to version `0.4.16`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ pandas==1.0.1
 matplotlib==3.1.3
 Pillow==7.0.0
 json-cfg==0.4.2
+
+# pin greenlet version (see https://github.com/phovea/phovea_server/issues/130)
+greenlet==0.4.16


### PR DESCRIPTION
Fixes #130

We decided to pin the greenlet to version `0.4.16` and postpone the update of the gevent version (see PR #131) as this requires further testing. 