### PR TITLE
Update to Flask 1.1.4 to fix Werkzeug error on start up

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
+Flask==1.1.4
 flask-restplus==0.13.0
 Flask-Sockets==0.2.1
 gevent==20.9.0


### PR DESCRIPTION
Closes #142 

### Summary

* Our current Flask version 1.1.2 uses any newer (also major) Werkzeug version as dependency
* Our Flask version breaks with the release [Werkzeug 2.0.0](https://pypi.org/project/Werkzeug/2.0.0/#history) a few days ago
* With Flask version 1.1.3 the Werkzeug version is limited to `<2.0.0` (see https://github.com/pallets/flask/commit/6d8b4ce9d037937ef8694067ab5754666240d097)
* [Flask changelog between 1.1.2 and 1.1.4](https://github.com/pallets/flask/compare/1.1.2...1.1.4)