### PR TITLE
Move docutils pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ pandas==1.1.4
 matplotlib==3.3.3
 Pillow==8.3.2
 json-cfg==0.4.2
+# Pin docutils to avoid AttributeError: 'Values' object has no attribute 'section_self_link'
+docutils==0.17.1


### PR DESCRIPTION
### Summary

* Move docutils pin from `tdp_core` to `phovea_server`