### PR TITLE
Release 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "phovea_server",
   "description": "Python server implementation of Phovea",
-  "version": "7.2.0",
+  "version": "7.2.1-SNAPSHOT",
   "author": {
     "name": "The Caleydo Team",
     "email": "contact@caleydo.org",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "phovea_server",
   "description": "Python server implementation of Phovea",
-  "version": "7.2.1-SNAPSHOT",
+  "version": "8.0.0",
   "author": {
     "name": "The Caleydo Team",
     "email": "contact@caleydo.org",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ pandas==1.1.4
 matplotlib==3.3.3
 Pillow==8.3.2
 json-cfg==0.4.2
-# Pin docutils to avoid AttributeError: 'Values' object has no attribute 'section_self_link'
 docutils==0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ pandas==1.1.4
 matplotlib==3.3.3
 Pillow==8.3.2
 json-cfg==0.4.2
+# Pin docutils to avoid AttributeError: 'Values' object has no attribute 'section_self_link'
+docutils==0.17.1


### PR DESCRIPTION
## Release notes

* Move docutils pin (phovea/phovea_server#148)


### Release dependencies first

In case of dependent Phovea/TDP repositories follow [dependency tree](https://wiki.datavisyn.io/phovea/fundamentals/development-process#dependency-hierarchy) from the top:

 
### 🏁 Finish line

* [ ] Inform colleagues and customers about the release
* [ ] Celebrate the new release 🥳