### PR TITLE
Add markupsafeto requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ Pillow==8.3.2
 json-cfg==0.4.2
 # Pin docutils to avoid AttributeError: 'Values' object has no attribute 'section_self_link'
 docutils==0.17.1
+# Pin markupsafe to avoid ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib/python3.7/site-packages/markupsafe/__init__.py) 
+markupsafe==2.0.1


### PR DESCRIPTION
fixes https://github.com/phovea/phovea_server/issues/154


Add markupsafe with a fixed version to the list of requirements to avoid the upgrade to 2.1.0 through our dependencies.