### PR TITLE
Added early return when mapping to same idtype

### DIFF
--- a/phovea_server/mapper.py
+++ b/phovea_server/mapper.py
@@ -130,6 +130,10 @@ class MappingManager(object):
     return list(self.paths.get(from_idtype, {}).keys())
 
   def __call__(self, from_idtype, to_idtype, ids):
+    # If both id types are the same, simply return
+    if from_idtype == to_idtype:
+      return ids
+
     # Get stored path instead of calculating them "on the fly"
     # paths = self.__find_all_paths(self.graph, from_idtype, to_idtype)
     paths = self.paths.get(from_idtype, {}).get(to_idtype)


### PR DESCRIPTION
Previously, mapping from `IDType1` to `IDType1` (the same one) returned null. 